### PR TITLE
Explain why we set a cookie

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -4,6 +4,9 @@ var hiddenFrames = require("sdk/frame/hidden-frame");
 var conntotal = 0;
 var connactive = 0;
 
+// force cookie creation to ensure maximum compatibility
+// (users might have manually set a cookie which disabled the proxy
+// on the script's options page)
 let optionFrame = hiddenFrames.add(hiddenFrames.HiddenFrame({
   onReady: function() {
     this.element.contentWindow.location = "http://crypto.stanford.edu/";


### PR DESCRIPTION
I was confused by this, since setting the cookie is not necessary. 
Then I understood that setting it ensures maximum compatibility.
